### PR TITLE
Change 0x0154:0x0004:0x0002 supported firmware version

### DIFF
--- a/packages/config/config/devices/0x0154/700854_2.0-255.255.json
+++ b/packages/config/config/devices/0x0154/700854_2.0-255.255.json
@@ -12,8 +12,8 @@
 		}
 	],
 	"firmwareVersion": {
-		"min": "2.4",
-		"max": "2.5"
+		"min": "2.0",
+		"max": "255.255"
 	},
 	"supportsZWavePlus": true,
 	"paramInformation": {


### PR DESCRIPTION
[Fix Issue 2405](https://github.com/zwave-js/node-zwave-js/issues/2405)

Popp Solar Siren 2
Manufacturer ID: 0x0154
Product type: 0x0004
Product ID: 0x0002

Change supported firwmare version  from 2.4 - 2.5 to 2.0 - 255.255.
Modified filename to reflect supported versionning.